### PR TITLE
Fix missing SDL.h

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,7 @@ echo -e "${RED}>>> No update. Installing development packages in 5 seconds.${NC}
 sleep 5
 
 sudo apt install unzip libgmp-dev libmpfr-dev libsdl2-dev autoconf -y
+( cd /usr/local/include/ ; sudo ln -s ../../include/SDL2 . ) # FIXME: Find a way without needing this
 
 echo -e "${RED}>>> Downloading Basilisk II in 5 seconds.${NC}"
 sleep 5


### PR DESCRIPTION
Fix missing `SDL.h` during compilation.

Thank you very much for this tremendously helpful piece of software. I have been trying to get this working for a very long time, however, I always struggled and got various kinds of errors. Your instructions helped me to get it running on a Raspberry Pi 3 and on a Raspberry Pi Zero 2 on the most recent Raspberry Pi OS as of this writing.