### PR TITLE
Boot faster and without text on screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,43 @@ Reboot your Raspberry Pi to test the configuration:
 sudo reboot
 ```
 
+#### Step 4: Cutting down boot time by skipping systemd
+
+Using an unmodified Raspberry Pi OS is not really suitable because the boot time is too long and too much stuff goes on on beforel macOS is booted. By skipping systemd one can dramatically cut down the boot process using a custom init script that just runs the bare minimum needed.
+
+Open the `~/basilisk_autostart.sh` file for editing:
+```bash
+sudo nano ~/basilisk_autostart.sh
+```
+
+```bash
+#!/bin/bash
+mount / -o remount,rw
+exec > /dev/null 2>&1
+export HOME=/home/pi
+cd ~
+/usr/local/bin/BasiliskII
+mount / -o remount,ro
+sync
+poweroff -f
+```
+
+Save and exit by pressing Ctrl + X, then Y, then Enter.
+
+Remove it from `/etc/rc.local` (that file never existed on my system in the first place).
+
+Open cmdline.txt:
+```bash
+sudo nano /boot/firmware/cmdline.txt
+```
+
+Add the following options to the end of the line:
+
+```plaintext
+quiet xinit=/home/pi/basilisk_autostart.sh
+```
+Save and exit by pressing Ctrl + X, then Y, then Enter.
+
 ## Getting help with Basilisk II, and Macintosh emulation in general
 - [E-Maculation wiki](https://www.emaculation.com/doku.php) setup guides for Basilisk II and other emulators
 - [E-Maculation forums](https://www.emaculation.com/forum/), active discussion about several Mac emulators]

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ sudo nano /boot/firmware/cmdline.txt
 Add the following options to the end of the line:
 
 ```plaintext
-quiet xinit=/home/pi/basilisk_autostart.sh
+quiet fastboot init=/home/pi/basilisk_autostart.sh
 ```
 Save and exit by pressing Ctrl + X, then Y, then Enter.
 


### PR DESCRIPTION
For a somewhat realistic emulation, using an unmodified Raspberry Pi OS is not really suitable because the boot time is too long and too much stuff goes on until macOS is booted. So, I propose to dramatically cut down the boot process by skipping systemd and instead having a custom init script that just runs the bare minimum needed.

The approach presented here
* Reduces boot time
* Gets rid of any text being printed on the screen before the emulation is started
* Shuts down the computer after the emulator shuts down

It is still possible to boot the normal Raspberry Pi OS occasionally (for maintenance tasks) by removing the `init=...` part, or by renaming it to, e.g., `xinit=...`.

If you like this way of doing things, feel free to change the `basilisk_autostart.sh` script in this repository accordingly.

TODO:
* Play a Macintosh [boot chime](https://www.soundboard.com/sb/Computer2)
* Intercept keyboard presses at boot time, e.g., "r" for "boot into full Raspberry Pi OS" or "s" for "boot into a shell"
* Get rid of the blinking cursor at boot (how?)
* Possibly launch network in the background (after the emulator has been launched) (can we get [GlobalTalk ](https://marchintosh.com/globaltalk.html) running?)